### PR TITLE
Expose commonAncestor from Hook

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,14 @@ const MyTextSelectionComponent = () => {
 }
 ```
 
+### Accessing the Common Ancestor
+
+You can access the closest, common ancestor to all elements within the selection with the `closestAncestor` return value. This is forwarded directly from the [commonAncestorContainer](https://developer.mozilla.org/en-US/docs/Web/API/Range/commonAncestorContainer) from the text range.
+
+```tsx
+const { clientRect, isCollapsed, commonAncestor } = useTextSelection(ref.current);
+```
+
 ## Work with me?
 
 I build editors for companies, or help their teams do so. Hit me up on [my website](http://jkrsp.com) to get in touch about a project.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,8 @@ function shallowDiff(prev: any, next: any) {
 type TextSelectionState = {
   clientRect?: ClientRect,
   isCollapsed?: boolean,
-  textContent?: string
+  textContent?: string,
+  commonAncestor?: Node
 }
 
 const defaultState: TextSelectionState = {}
@@ -47,6 +48,7 @@ export function useTextSelection(target?: HTMLElement) {
     clientRect,
     isCollapsed,
     textContent,
+    commonAncestor,
   }, setState] = useState<TextSelectionState>(defaultState)
 
   const reset = useCallback(() => {
@@ -94,6 +96,7 @@ export function useTextSelection(target?: HTMLElement) {
       newState.clientRect = newRect
     }
     newState.isCollapsed = range.collapsed
+    newState.commonAncestor = range.commonAncestorContainer
 
     setState(newState)
   }, [target])
@@ -115,6 +118,7 @@ export function useTextSelection(target?: HTMLElement) {
   return {
     clientRect,
     isCollapsed,
-    textContent
+    textContent,
+    commonAncestor,
   }
 }


### PR DESCRIPTION
I wanted access to the `commonAncestor` property of the document's current selection.

Pretty simple change. Let me know if there are any issues or concerns (I haven't worked extensively with the selection API in Javascript).